### PR TITLE
Przeoranie całego frontu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,32 @@
+# CO TO CORE, PLUGINY I RENDERERY
+
+## CORE
+
+Główny moduł aplikacji w który jest zaimplementowana cała logika.
+
+Podział zadań:
+
+- Dla laików:
+  - Implementacja pluginu napisanego przez kogoś innego
+- Dla programistów:
+  - Implementacja nowego pluginu
+  - Implementacja nowego renderera
+
+## PLUGINY
+
+- Każdy plugin to osobny moduł aplikacji, nie powinny być zależne od siebie
+
+## RENDERERY
+
+- Umożliwiają wyświetlanie danych w różny sposób, używane są w pluginach. Mogą być używane w wielu pluginach na raz.
+
 # WSB-CW8-Group-Project
+
 Project created during cooperative programming class.
 
 dupududpuudpdupupdupddupdupdup
 
-test 
+test
 
 Przepis na bigos
 
@@ -15,9 +38,10 @@ Kiełbasę obrać ze skóry, pokroić w kostkę i podsmażyć na patelni. Dodać
 Mąkę podsmażyć na suchej patelni, gdy zacznie brązowieć dodać łyżkę masła i mieszać aż masło się rozpuści.
 Trzymając patelnię na ogniu dodać stopniowo kilka łyżek kapusty cały czas mieszając. Przełożyć zawartość patelni z powrotem do garnka, wymieszać i zagotować
 
-
 # BACKEND-SETUP
+
 TODO cała ścieżka do postawienia backendu (kopia application.properties na application-local.properties, uzupełnienie danych, uruchomienie dockera itd)
 
 # FRONTEND-SETUP
+
 TODO - cała ścieżka do postawienia frontu (kopia env'a, npm install itd)

--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ Podział zadań:
 
 - Umożliwiają wyświetlanie danych w różny sposób, używane są w pluginach. Mogą być używane w wielu pluginach na raz.
 
+## JAK UŻYĆ PLUGINA?
+
+```
+const main = new Root([
+NowyPluginDodanyPrzezCiebie(Opcje Do inicjalizacji)
+]);
+```
+
+Dorzucamy plugin do Roota, który jest głównym modułem aplikacji. Nie musimy się martwić o to, że pluginy będą się ze sobą gryźć, ponieważ są one od siebie niezależne (Przynajmniej powinny jak nic nie zepsuliśmy).
+
 # WSB-CW8-Group-Project
 
 Project created during cooperative programming class.

--- a/fe/.env.example
+++ b/fe/.env.example
@@ -1,2 +1,2 @@
 VITE_API_KEY="someApiKeyToChangeLocally" # Gdyby ktoś chciał postawić front bez backendu należy też zmienić VITE_API_URL
-VITE_API_URL="http://localhost:8080/buses"
+VITE_API_URL="http://localhost:8080"

--- a/fe/src/core/interfaces.ts
+++ b/fe/src/core/interfaces.ts
@@ -1,0 +1,11 @@
+export interface BasePlugin {
+  initialize(): void;
+}
+
+export interface BaseRenderer<T> {
+  render(data: T): void;
+}
+
+export interface BaseDataFetcher<T> {
+  fetchData(path: string): Promise<T>;
+}

--- a/fe/src/core/plugins/BusPlugin.ts
+++ b/fe/src/core/plugins/BusPlugin.ts
@@ -1,0 +1,33 @@
+import { BaseDataFetcher, BasePlugin, BaseRenderer } from "../interfaces";
+import { BusData } from "../types";
+
+const BUS_API_PATH = "/buses";
+
+class BusPlugin implements BasePlugin {
+  private dataFetcher: BaseDataFetcher<BusData[]>;
+  private renderer: BaseRenderer<BusData[]>;
+
+  constructor(
+    dataFetcher: BaseDataFetcher<BusData[]>,
+    renderer: BaseRenderer<BusData[]>
+  ) {
+    this.renderer = renderer;
+    this.dataFetcher = dataFetcher;
+  }
+
+  async initialize(): Promise<void> {
+    try {
+      const data = await this.dataFetcher.fetchData(BUS_API_PATH);
+      this.renderer.render(data);
+    } catch (e) {
+      console.error("Failed to fetch data", e);
+    }
+  }
+}
+
+export const busPlugin = (
+  dataFetcher: BaseDataFetcher<BusData[]>,
+  renderer: BaseRenderer<BusData[]>
+): BasePlugin => {
+  return new BusPlugin(dataFetcher, renderer);
+};

--- a/fe/src/core/plugins/MapPlugin.ts
+++ b/fe/src/core/plugins/MapPlugin.ts
@@ -1,0 +1,28 @@
+import L, { LatLngExpression } from "leaflet";
+import { BasePlugin } from "../interfaces";
+
+const TILE_URL = "https://tile.openstreetmap.org/{z}/{x}/{y}.png";
+const ATTRIBUTION =
+  '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>';
+
+const WARSAW_COORDINATES: LatLngExpression = [52.259788, 21.040546];
+const ZOOM = 13;
+
+class MapPlugin implements BasePlugin {
+  private map: L.Map;
+
+  constructor(map: L.Map) {
+    this.map = map;
+  }
+
+  initialize(): void {
+    this.map.setView(WARSAW_COORDINATES, ZOOM);
+    L.tileLayer(TILE_URL, {
+      attribution: ATTRIBUTION,
+    }).addTo(this.map);
+  }
+}
+
+export const mapPlugin = (map: L.Map): BasePlugin => {
+  return new MapPlugin(map);
+};

--- a/fe/src/core/plugins/TitlePlugin.ts
+++ b/fe/src/core/plugins/TitlePlugin.ts
@@ -1,0 +1,19 @@
+import { BasePlugin } from "../interfaces";
+
+class TitlePlugin implements BasePlugin {
+  private title: string;
+
+  constructor(title: string) {
+    this.title = title;
+  }
+
+  initialize(): void {
+    const titleElement = document.createElement("h1");
+    titleElement.innerText = this.title;
+    document.body.prepend(titleElement);
+  }
+}
+
+export const titlePlugin = (title: string): BasePlugin => {
+  return new TitlePlugin(title);
+};

--- a/fe/src/core/renderers/MarkerRenderer.ts
+++ b/fe/src/core/renderers/MarkerRenderer.ts
@@ -1,0 +1,22 @@
+import { BaseRenderer } from "../interfaces";
+import { BusData } from "../types";
+import L from "leaflet";
+
+export class MarkerRenderer implements BaseRenderer<BusData[]> {
+  private map: L.Map;
+
+  constructor(map: L.Map) {
+    this.map = map;
+  }
+
+  render(data: BusData[]): void {
+    if (!data) {
+      // TODO: SOME BETTER ERROR HANDLING, MAYBE RETRY?
+      return console.error("No data to render");
+    }
+
+    data.forEach((bus) => {
+      L.marker([bus.lat, bus.lon]).addTo(this.map);
+    });
+  }
+}

--- a/fe/src/core/root.ts
+++ b/fe/src/core/root.ts
@@ -1,0 +1,15 @@
+import { BasePlugin } from "./interfaces";
+
+export class Root {
+  private plugins: BasePlugin[];
+
+  constructor(plugins: BasePlugin[]) {
+    this.plugins = plugins;
+  }
+
+  async initialize() {
+    for (const plugin of this.plugins) {
+      plugin.initialize();
+    }
+  }
+}

--- a/fe/src/core/types.ts
+++ b/fe/src/core/types.ts
@@ -1,0 +1,12 @@
+import { BasePlugin } from "./interfaces";
+
+export type BusData = {
+  lat: number;
+  lon: number;
+  lines: string;
+  vehiclenumber: string;
+  time: string;
+  brigade: string;
+};
+
+export type GetPlugin = <T>(options: T) => BasePlugin;

--- a/fe/src/core/utils/dataFetcher.ts
+++ b/fe/src/core/utils/dataFetcher.ts
@@ -1,0 +1,21 @@
+import { BaseDataFetcher } from "../interfaces";
+import { BusData } from "../types";
+
+export class DataFetcher implements BaseDataFetcher<BusData[]> {
+  private apiUrl: string;
+
+  constructor(apiUrl: string) {
+    this.apiUrl = apiUrl;
+  }
+
+  async fetchData(path: string): Promise<BusData[]> {
+    try {
+      const response = await fetch(this.apiUrl + path);
+      const data = await response.json();
+      return data.result;
+    } catch (e) {
+      console.error("Failed to fetch data", e);
+      throw e;
+    }
+  }
+}

--- a/fe/src/main.ts
+++ b/fe/src/main.ts
@@ -1,40 +1,27 @@
 import "./style.css";
 import "leaflet/dist/leaflet.css";
 import L from "leaflet";
+import { busPlugin } from "./core/plugins/BusPlugin";
+import { mapPlugin } from "./core/plugins/MapPlugin";
+import { Root } from "./core/root";
+import { DataFetcher } from "./core/utils/dataFetcher";
+import { MarkerRenderer } from "./core/renderers/MarkerRenderer";
+import { titlePlugin } from "./core/plugins/TitlePlugin";
+
+const API_URL = import.meta.env.VITE_API_URL;
+
+const dataFetcher = new DataFetcher(API_URL);
 
 document.querySelector<HTMLDivElement>("#app")!.innerHTML = `
-  
-    <div>
-      <h1>Tutaj coś będzie kiedyś</h1>
-    </div>
-    
-    <div id="map"></div>
- 
+<div id="map"></div>
 `;
 
-const map = L.map("map").setView([52.259788, 21.040546], 13);
+const mapInstance = L.map("map"); // Assuming you have a map instance
 
-// Load and display tile layer (OpenStreetMap tiles)
-L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
-  attribution: "&copy; OpenStreetMap contributors",
-}).addTo(map);
+const main = new Root([
+  titlePlugin("Warsaw Buses"),
+  mapPlugin(mapInstance),
+  busPlugin(dataFetcher, new MarkerRenderer(mapInstance)),
+]);
 
-const fetchBusData = async () => {
-    const apiUrl = import.meta.env.VITE_API_URL;
-    try {
-        const response = await fetch(apiUrl);
-        if (!response.ok) {
-            throw new Error(`HTTP error! Status: ${response.status}`);
-        }
-        return await response.json();
-    } catch (error) {
-        console.error("Failed to fetch data:", error);
-    }
-};
-
-const renderBuses = async () => {
-    const busData = await fetchBusData();
-    console.log(busData.result);
-}
-
-renderBuses().then(() => console.log("Buses rendered")); //TODO do implementacji w dalszych taskach
+main.initialize();


### PR DESCRIPTION
## Cel tych zmian: 
Sprawienie aby ludzie co nie ogarniają/się nie chce, nie musieli orać tony kodu, tylko zaimportowali wcześniej napisany plugin. Wykładowca zadowolony bo wszyscy wrzucili commit i fajrant. 

Ten pull request wprowadza znaczące zmiany w architekturze frontendowej, w tym dodanie interfejsów dla pluginów i rendererów, nowe pluginy oraz refaktoryzację logiki inicjalizacji głównej aplikacji. 

# CO TO CORE, PLUGINY I RENDERERY

## CORE

Główny moduł aplikacji w który jest zaimplementowana cała logika.

Podział zadań:

- Dla leniuchów:
  - Implementacja pluginu napisanego przez kogoś innego
- Dla chętnych:
  - Implementacja nowego pluginu
  - Implementacja nowego renderera

## PLUGINY

- Każdy plugin to osobny moduł aplikacji, nie powinny być zależne od siebie

Edge case: MapPlugin -> wymagany do całości aplikacji 

## RENDERERY

- Umożliwiają wyświetlanie danych w różny sposób, używane są w pluginach. Mogą być używane w wielu pluginach na raz.

## JAK UŻYĆ PLUGINA?

```
const main = new Root([
NowyPluginDodanyPrzezCiebie(Opcje Do inicjalizacji)
]);
```

Dorzucamy plugin do Roota, który jest głównym modułem aplikacji. Nie musimy się martwić o to, że pluginy będą się ze sobą gryźć, ponieważ są one od siebie niezależne (Przynajmniej powinny, chyba że wyjdzie inaczej).

Jeszcze nie wiem jak to będzie się tyczyło innych tasków, ale wszystko jest lepsze niż 1000+ linijkowy main